### PR TITLE
fix(cmd): use config-enriched defaults in alias invoker

### DIFF
--- a/src/plugins/cmd/alias.test.ts
+++ b/src/plugins/cmd/alias.test.ts
@@ -57,6 +57,42 @@ describe('plugins/cmd option alias', () => {
     expect(command).toBe('echo BAR');
   });
 
+  it('resolves env-specific vars via rootOptionDefaults in alias path', async () => {
+    // Regression: the cmd alias invoker used bare baseGetDotenvCliOptions
+    // (baseRootOptionDefaults) as defaults, missing project rootOptionDefaults
+    // like paths and defaultEnv. This caused the alias to clobber the
+    // correctly-resolved context from root hooks with incomplete defaults,
+    // losing env-specific variables.
+    const run = createCli({
+      alias: 'test',
+      rootOptionDefaults: {
+        paths: './test/full',
+        dotenvToken: '.testenv',
+        defaultEnv: 'test',
+        loadProcess: true,
+      },
+      compose: (p) =>
+        p.use(
+          cmdPlugin({ asDefault: true, optionAlias: '-c, --cmd <command...>' }),
+        ),
+    });
+
+    await run(['node', 'test', '-c', 'echo', 'OK']);
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const [, opts] = execMock.mock.calls[0] as [
+      string,
+      { env?: Record<string, string> },
+    ];
+    // The child env should include ENV_SETTING from .testenv.test
+    // (env-specific file under the custom paths/defaultEnv).
+    // Before the fix, paths defaulted to './' and defaultEnv was absent,
+    // so env-specific files were never loaded.
+    expect(opts.env?.ENV_SETTING).toBe('deep_test_setting');
+    // Global var should also be present.
+    expect(opts.env?.APP_SETTING).toBe('deep_app_setting');
+  });
+
   it('conflicts when alias and cmd subcommand are both provided', async () => {
     // Spy process.exit (defaultCmdAction exits on conflict); do not terminate tests.
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {

--- a/src/plugins/cmd/parentInvoker.ts
+++ b/src/plugins/cmd/parentInvoker.ts
@@ -9,11 +9,13 @@ import {
   type RootOptionsShape,
   type ScriptsTable,
 } from '@/src/cliHost';
+import { resolveGetDotenvConfigSources } from '@/src/config';
 import {
   getDotenvCliOptions2Options,
   type RootOptionsShapeCompat,
 } from '@/src/core';
 import { dotenvExpandFromProcessEnv } from '@/src/dotenv';
+import { defaultsDeep } from '@/src/util';
 
 import type { CmdPlugin } from '.';
 import { runCmdWithContext } from './runner';
@@ -112,13 +114,22 @@ export const attachCmdParentInvoker = (
     aliasState.handled = true;
 
     // Merge CLI options and resolve dotenv context for this invocation.
+    // Use config-enriched defaults (not bare baseGetDotenvCliOptions) so
+    // project rootOptionDefaults (paths, defaultEnv, etc.) are respected.
+    const sources = await resolveGetDotenvConfigSources(import.meta.url);
+    const cfgDefaults = defaultsDeep<Partial<RootOptionsShape>>(
+      {},
+      sources.packaged?.rootOptionDefaults ?? {},
+      sources.project?.public?.rootOptionDefaults ?? {},
+      sources.project?.local?.rootOptionDefaults ?? {},
+    );
+    const enrichedDefaults = defaultsDeep<Partial<RootOptionsShape>>(
+      baseGetDotenvCliOptions as Partial<RootOptionsShape>,
+      cfgDefaults,
+    );
     const { merged } = resolveCliOptions<
       RootOptionsShape & { scripts?: ScriptsTable }
-    >(
-      raw,
-      baseGetDotenvCliOptions as Partial<RootOptionsShape>,
-      process.env.getDotenvCliOptions,
-    );
+    >(raw, enrichedDefaults, process.env.getDotenvCliOptions);
     const serviceOptions = getDotenvCliOptions2Options(
       merged as unknown as RootOptionsShapeCompat,
     );

--- a/src/plugins/cmd/parentInvoker.ts
+++ b/src/plugins/cmd/parentInvoker.ts
@@ -117,15 +117,11 @@ export const attachCmdParentInvoker = (
     // Use config-enriched defaults (not bare baseGetDotenvCliOptions) so
     // project rootOptionDefaults (paths, defaultEnv, etc.) are respected.
     const sources = await resolveGetDotenvConfigSources(import.meta.url);
-    const cfgDefaults = defaultsDeep<Partial<RootOptionsShape>>(
-      {},
-      sources.packaged?.rootOptionDefaults ?? {},
-      sources.project?.public?.rootOptionDefaults ?? {},
-      sources.project?.local?.rootOptionDefaults ?? {},
-    );
     const enrichedDefaults = defaultsDeep<Partial<RootOptionsShape>>(
       baseGetDotenvCliOptions as Partial<RootOptionsShape>,
-      cfgDefaults,
+      sources.packaged?.rootOptionDefaults,
+      sources.project?.public?.rootOptionDefaults,
+      sources.project?.local?.rootOptionDefaults,
     );
     const { merged } = resolveCliOptions<
       RootOptionsShape & { scripts?: ScriptsTable }


### PR DESCRIPTION
## Summary

- The cmd `parentInvoker` used bare `baseGetDotenvCliOptions` (`baseRootOptionDefaults`) as defaults when re-resolving context for alias invocations. This missed project-level `rootOptionDefaults` like `paths`, `defaultEnv`, and `dotenvToken`, causing the alias path to clobber the correctly-resolved context from root hooks with incomplete defaults.
- The fix passes the config-enriched `rootOptionDefaults` through to the alias invoker so that re-resolution preserves the full project context.
- Added a regression test that verifies env-specific variables (e.g. from `.testenv.test` under custom paths/defaultEnv) are correctly loaded through the alias path.

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] All 210 tests pass (`vitest run`)
- [x] Lint passes (`eslint src`)
- [x] New regression test covers the specific failure scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)