### PR TITLE
fix(lint): add vitest settings to eslint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -140,6 +140,11 @@ export default [
     plugins: {
       vitest: vitestPlugin,
     },
+    settings: {
+      vitest: {
+        typecheck: true,
+      },
+    },
     rules: {
       // Apply Vitest recommended and allow projects to override locally if needed
       ...vitestRecommendedRules,


### PR DESCRIPTION
The @vitest/eslint-plugin@1.6.6 no-standalone-expect rule crashes with TypeError: Cannot read properties of undefined (reading additionalTestBlockFunctions) when the test file eslint config block lacks a settings.vitest object. This adds settings: { vitest: { typecheck: true } } to the test file config block in eslint.config.ts, providing the required settings object and fixing the crash.