### PR TITLE
fix: propagate resolved env into plugin options bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Author config in JSON/YAML/JS/TS at your project root. The loader is always on i
 - Dynamic (JS/TS only): `dynamic`
 - Validation (JS/TS schema or required keys): `schema`, `requiredKeys`
 
+Set the target environment dynamically: `defaultEnvKey` names a variable in your global dotenv files (default: `DEFAULT_ENV`) that overrides the static `defaultEnv` when `-e` is not provided.
+
 Overlays apply by kind/env/privacy/source with clear precedence. Details and examples in the [Config guide](./guides/config.md).
 
 ## Dynamic variables (JS/TS)

--- a/guides/cascade.md
+++ b/guides/cascade.md
@@ -23,6 +23,14 @@ Per input path, the loader evaluates up to four files in this order:
 
 If a file is missing, it is silently skipped. Parsed values from later files override earlier ones (e.g., private values override public values).
 
+## Environment resolution
+
+When `env` is not set via `-e`, `get-dotenv` performs a global-only pre-pass — loading only global dotenv files (excluding env-scoped files) — and checks for a variable named by `defaultEnvKey` (default: `DEFAULT_ENV`).
+
+Resolution order: explicit `-e` > `defaultEnvKey` value from global files > static `defaultEnv` from config.
+
+The resolved environment then determines which env-scoped files (e.g., `.env.dev`, `.env.dev.local`) are loaded in the full cascade.
+
 ## Multiple paths
 
 When `paths` contains more than one directory, `get-dotenv` visits each directory in the order they appear in the array. For each directory, the same four-file cascade is applied and merged into the overall result. Later paths override earlier paths for colliding keys.

--- a/guides/config.md
+++ b/guides/config.md
@@ -40,7 +40,7 @@ JSON/YAML (data only, always-on; no-op when no files are present):
 
 - Allowed keys:
   - rootOptionDefaults?: Partial<RootOptionsShape> — collapsed, CLI‑like flags and strings. Supported keys:
-    - Targeting: `env`, `defaultEnv`, `paths`, `pathsDelimiter`, `pathsDelimiterPattern`, `dotenvToken`, `privateToken`.
+    - Targeting: `env`, `defaultEnv`, `defaultEnvKey`, `paths`, `pathsDelimiter`, `pathsDelimiterPattern`, `dotenvToken`, `privateToken`.
     - Output/Vars: `vars`, `varsAssignor`, `varsAssignorPattern`, `varsDelimiter`, `varsDelimiterPattern`, `outputPath`.
     - Loading: `loadProcess`, `dynamicPath`.
     - Exclusions: `excludeAll`, `excludeDynamic`, `excludeEnv`, `excludeGlobal`, `excludePrivate`, `excludePublic`.
@@ -94,6 +94,18 @@ The overlay flow:
 2. Overlay config sources in order: packaged (public only) → project public → project local.
 3. Apply dynamic in order: programmatic dynamic (if provided) → config dynamic from JS/TS (packaged → project public → project local) → file dynamicPath (lowest dynamic tier).
 4. Optional effects: outputPath (write consolidated dotenv; quote multiline), log (print final map), loadProcess (merge into process.env).
+
+## Environment resolution order
+
+When no explicit `-e` flag is provided, `get-dotenv` resolves the target environment in three tiers:
+
+1. **Explicit `-e` flag** — highest priority, used as-is.
+2. **`defaultEnvKey` lookup** — a global-only pre-pass loads dotenv files (excluding env-scoped files) and looks up the variable named by `defaultEnvKey` (default: `DEFAULT_ENV`). If found, its value becomes the resolved environment.
+3. **Static `defaultEnv`** — the fallback from config if neither of the above produces a value.
+
+Example: if `.env.local` contains `DEFAULT_ENV=bali` and your config sets `defaultEnv: 'dev'`, the resolved environment is `bali` (tier 2 wins over tier 3).
+
+By the time plugins run, `bag.env` is always the fully resolved environment — plugins never need to handle defaulting themselves.
 
 ## Interpolation and expansion model
 

--- a/src/cliHost/computeContext.ts
+++ b/src/cliHost/computeContext.ts
@@ -306,6 +306,7 @@ export const computeContext = async <
   }
 
   return {
+    ...(typeof envName === 'string' ? { env: envName } : {}),
     optionsResolved: validated as TOptions,
     dotenv,
     dotenvProvenance,

--- a/src/cliHost/defaultEnvKey.test.ts
+++ b/src/cliHost/defaultEnvKey.test.ts
@@ -4,6 +4,8 @@ import fs from 'fs-extra';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { GetDotenvCli } from './GetDotenvCli';
+import type { GetDotenvCliOptions } from './GetDotenvCliOptions';
+import { readMergedOptions } from './readMergedOptions';
 
 const ROOT = path.posix.join('.tsbuild', 'defaultEnvKey.tests');
 
@@ -303,6 +305,63 @@ describe('defaultEnvKey pre-pass resolution', () => {
       });
 
       expect(ctx.dotenv.ENV_SETTING).toBe('from_test');
+    } finally {
+      await fs.remove(base);
+    }
+  });
+
+  it('exposes resolved env on context when defaultEnvKey resolves it', async () => {
+    const base = path.posix.join(ROOT, 'ctx-env');
+    await fs.remove(base);
+    await fs.ensureDir(base);
+
+    // Global public: DEFAULT_ENV=bali
+    await fs.writeFile(
+      path.posix.join(base, '.testenv'),
+      'DEFAULT_ENV=bali\n',
+      { encoding: 'utf-8' },
+    );
+    // Env-scoped for bali
+    await fs.writeFile(
+      path.posix.join(base, '.testenv.bali'),
+      'ENV_SETTING=from_bali\n',
+      { encoding: 'utf-8' },
+    );
+
+    try {
+      const cli = new GetDotenvCli('test');
+      const ctx = await cli.resolveAndLoad({
+        dotenvToken: '.testenv',
+        privateToken: 'secret',
+        paths: [base],
+        defaultEnv: 'dev',
+        loadProcess: false,
+      });
+
+      // ctx.env should reflect the dynamically resolved env, not the static defaultEnv
+      expect(ctx.env).toBe('bali');
+      expect(ctx.dotenv.ENV_SETTING).toBe('from_bali');
+
+      // Simulate rootHooks propagation: set an initial bag with defaultEnv='dev',
+      // then propagate the resolved env back into bag.env.
+      cli._setOptionsBag({
+        defaultEnv: 'dev',
+      } as unknown as GetDotenvCliOptions);
+      if (cli.hasCtx()) {
+        const resolvedCtx = cli.getCtx();
+        if (resolvedCtx.env) {
+          const bag = cli.getOptions();
+          if (bag) {
+            (bag as Record<string, unknown>).env = resolvedCtx.env;
+            cli._setOptionsBag(bag);
+          }
+        }
+      }
+
+      // readMergedOptions should return a bag where bag.env equals the resolved env —
+      // plugins see bag.env = 'bali' even though no -e flag was passed.
+      const mergedBag = readMergedOptions(cli);
+      expect(mergedBag.env).toBe('bali');
     } finally {
       await fs.remove(base);
     }

--- a/src/cliHost/rootHooks.ts
+++ b/src/cliHost/rootHooks.ts
@@ -63,6 +63,24 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
   program: GetDotenvCli<TOptions>,
   defaults?: Partial<RootOptionsShape>,
 ): GetDotenvCli<TOptions> {
+  // Propagate resolved env into the options bag so plugins always see
+  // the effective environment as bag.env — no defaulting logic needed downstream.
+  const propagateResolvedEnv = (
+    merged: RootOptionsShape & { scripts?: ScriptsTable },
+  ) => {
+    if (program.hasCtx()) {
+      const resolvedCtx = program.getCtx();
+      if (resolvedCtx.env) {
+        merged.env = resolvedCtx.env;
+        (
+          program as unknown as {
+            _setOptionsBag: (b: GetDotenvCliOptions) => void;
+          }
+        )._setOptionsBag(merged as unknown as GetDotenvCliOptions);
+      }
+    }
+  };
+
   // Hook: preSubcommand — always runs for subcommand flows.
   program.hook('preSubcommand', async (thisCommand) => {
     const sources = await resolveGetDotenvConfigSources(import.meta.url);
@@ -109,19 +127,7 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
     ) as unknown as Partial<TOptions>;
     await program.resolveAndLoad(serviceOptions);
 
-    // Propagate resolved env into the options bag so plugins always see
-    // the effective environment as bag.env — no defaulting logic needed downstream.
-    if (program.hasCtx()) {
-      const resolvedCtx = program.getCtx();
-      if (resolvedCtx.env) {
-        (merged as Record<string, unknown>).env = resolvedCtx.env;
-        (
-          program as unknown as {
-            _setOptionsBag: (b: GetDotenvCliOptions) => void;
-          }
-        )._setOptionsBag(merged as unknown as GetDotenvCliOptions);
-      }
-    }
+    propagateResolvedEnv(merged);
 
     // Refresh dynamic help text using the resolved config slices.
     try {
@@ -194,19 +200,7 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
       ) as unknown as Partial<TOptions>;
       await program.resolveAndLoad(serviceOptions);
 
-      // Propagate resolved env into the options bag so plugins always see
-      // the effective environment as bag.env — no defaulting logic needed downstream.
-      if (program.hasCtx()) {
-        const resolvedCtx = program.getCtx();
-        if (resolvedCtx.env) {
-          (merged as Record<string, unknown>).env = resolvedCtx.env;
-          (
-            program as unknown as {
-              _setOptionsBag: (b: GetDotenvCliOptions) => void;
-            }
-          )._setOptionsBag(merged as unknown as GetDotenvCliOptions);
-        }
-      }
+      propagateResolvedEnv(merged);
 
       try {
         const ctx = program.getCtx();

--- a/src/cliHost/rootHooks.ts
+++ b/src/cliHost/rootHooks.ts
@@ -109,6 +109,20 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
     ) as unknown as Partial<TOptions>;
     await program.resolveAndLoad(serviceOptions);
 
+    // Propagate resolved env into the options bag so plugins always see
+    // the effective environment as bag.env — no defaulting logic needed downstream.
+    if (program.hasCtx()) {
+      const resolvedCtx = program.getCtx();
+      if (resolvedCtx.env) {
+        (merged as Record<string, unknown>).env = resolvedCtx.env;
+        (
+          program as unknown as {
+            _setOptionsBag: (b: GetDotenvCliOptions) => void;
+          }
+        )._setOptionsBag(merged as unknown as GetDotenvCliOptions);
+      }
+    }
+
     // Refresh dynamic help text using the resolved config slices.
     try {
       const ctx = program.getCtx();
@@ -179,6 +193,21 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
         merged,
       ) as unknown as Partial<TOptions>;
       await program.resolveAndLoad(serviceOptions);
+
+      // Propagate resolved env into the options bag so plugins always see
+      // the effective environment as bag.env — no defaulting logic needed downstream.
+      if (program.hasCtx()) {
+        const resolvedCtx = program.getCtx();
+        if (resolvedCtx.env) {
+          (merged as Record<string, unknown>).env = resolvedCtx.env;
+          (
+            program as unknown as {
+              _setOptionsBag: (b: GetDotenvCliOptions) => void;
+            }
+          )._setOptionsBag(merged as unknown as GetDotenvCliOptions);
+        }
+      }
+
       try {
         const ctx = program.getCtx();
         const helpCfg = toHelpConfig(merged, ctx.pluginConfigs);

--- a/src/cliHost/types.ts
+++ b/src/cliHost/types.ts
@@ -153,6 +153,10 @@ export interface GetDotenvCliCtx<
   TOptions extends GetDotenvOptions = GetDotenvOptions,
 > {
   /**
+   * Effective environment name after resolution (explicit -e \> defaultEnvKey \> defaultEnv).
+   */
+  env?: string;
+  /**
    * Fully resolved option bag used to compute this context.
    */
   optionsResolved: TOptions;


### PR DESCRIPTION
## Problem

When `defaultEnvKey` resolves the environment dynamically (e.g. `DEFAULT_ENV=bali` in a global dotenv file), the resolved value was correctly used for the file cascade and available as `ctx.dotenv.ENV`, but plugin actions reading `readMergedOptions()` still saw `bag.env = undefined` and `bag.defaultEnv = 'dev'` (the static config default).

Downstream plugins using `bag.env ?? bag.defaultEnv` to determine env-scoped write targets (e.g. `editDotenvFile` in aws-api-gateway-tools) would write to the wrong file (`.env.dev.local` instead of `.env.bali.local`).

## Fix

- Expose `env` on `GetDotenvCliCtx` — the effective environment after resolution (explicit `-e` > `defaultEnvKey` > `defaultEnv`).
- In `rootHooks.ts`, after `resolveAndLoad()`, propagate `ctx.env` back into `merged.env` and re-persist the options bag.

**Zero downstream impact:** plugins using `bag.env` (or `bag.env ?? bag.defaultEnv`) now see the resolved environment automatically. No plugin changes required.

## Docs

- `guides/config.md` — added `defaultEnvKey` to targeting list + new "Environment resolution order" section
- `guides/cascade.md` — new "Environment resolution" section
- `README.md` — brief `defaultEnvKey` note

## Test

New test in `defaultEnvKey.test.ts` verifies:
- `ctx.env` reflects the dynamically resolved env
- `readMergedOptions()` returns `bag.env = 'bali'` after propagation
