### PR TITLE
fix: propagate resolved env in preAction for subcommand flows

### DIFF
--- a/src/cliHost/preActionPropagateEnv.test.ts
+++ b/src/cliHost/preActionPropagateEnv.test.ts
@@ -1,0 +1,73 @@
+import path from 'node:path';
+
+import type { CommandUnknownOpts } from '@commander-js/extra-typings';
+import fs from 'fs-extra';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createCli } from '@/src/cli';
+import { definePlugin } from '@/src/cliHost/definePlugin';
+
+import type { GetDotenvCliOptions } from './GetDotenvCliOptions';
+import { readMergedOptions } from './readMergedOptions';
+
+const ROOT = path.posix.join('.tsbuild', 'preActionPropagateEnv.tests');
+
+describe('preAction propagates resolved env for subcommand flows', () => {
+  beforeEach(() => {
+    delete process.env.DEFAULT_ENV;
+    delete process.env.APP_SETTING;
+    delete process.env.ENV_SETTING;
+  });
+
+  afterEach(async () => {
+    await fs.remove(ROOT);
+  });
+
+  it('readMergedOptions returns bag with env populated via defaultEnv in subcommand flow', async () => {
+    const base = path.posix.join(ROOT, 'subcommand-env');
+    await fs.remove(base);
+    await fs.ensureDir(base);
+
+    // Global public: DEFAULT_ENV=dev
+    await fs.writeFile(path.posix.join(base, '.testenv'), 'DEFAULT_ENV=dev\n', {
+      encoding: 'utf-8',
+    });
+    // Env-scoped public for dev
+    await fs.writeFile(
+      path.posix.join(base, '.testenv.dev'),
+      'ENV_SETTING=from_dev\n',
+      { encoding: 'utf-8' },
+    );
+
+    let capturedBag: GetDotenvCliOptions | undefined;
+
+    // A minimal plugin whose action captures the merged options bag.
+    const capturePlugin = definePlugin({
+      ns: 'capture',
+      setup(cli) {
+        cli.action(function (this: CommandUnknownOpts) {
+          capturedBag = readMergedOptions(this);
+        });
+      },
+    });
+
+    const run = createCli({
+      alias: 'test',
+      rootOptionDefaults: {
+        dotenvToken: '.testenv',
+        privateToken: 'secret',
+        paths: [base],
+        loadProcess: false,
+      },
+      compose: (prog) => prog.use(capturePlugin),
+    });
+
+    // Invoke without explicit -e flag — env should resolve from DEFAULT_ENV=dev
+    await run(['node', 'test', 'capture']);
+
+    // The critical assertion: bag.env must be populated from the resolved context,
+    // not undefined due to preAction overwriting the bag without propagation.
+    expect(capturedBag).toBeDefined();
+    expect((capturedBag as GetDotenvCliOptions).env).toBe('dev');
+  });
+});

--- a/src/cliHost/rootHooks.ts
+++ b/src/cliHost/rootHooks.ts
@@ -199,32 +199,33 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
         merged,
       ) as unknown as Partial<TOptions>;
       await program.resolveAndLoad(serviceOptions);
+    }
 
-      propagateResolvedEnv(merged);
+    // Always propagate resolved env into the merged bag — even when
+    // preSubcommand already set the context.  preAction unconditionally
+    // builds a fresh `merged` and overwrites the options bag, so the env
+    // propagated by preSubcommand is lost without this call.
+    propagateResolvedEnv(merged);
 
-      try {
-        const ctx = program.getCtx();
-        const helpCfg = toHelpConfig(merged, ctx.pluginConfigs);
-        program.evaluateDynamicOptions(helpCfg);
-      } catch {
-        /* tolerate */
+    try {
+      const ctx = program.getCtx();
+      const helpCfg = toHelpConfig(merged, ctx.pluginConfigs);
+      program.evaluateDynamicOptions(helpCfg);
+    } catch {
+      /* tolerate */
+    }
+    try {
+      const ctx = program.getCtx();
+      const issues = validateEnvAgainstSources(ctx.dotenv, sources);
+      if (Array.isArray(issues) && issues.length > 0) {
+        const logger = (merged as unknown as GetDotenvCliOptions).logger;
+        issues.forEach((m) => {
+          logger.error(m);
+        });
+        if ((merged as unknown as GetDotenvCliOptions).strict) process.exit(1);
       }
-      try {
-        const ctx = program.getCtx();
-        const dotenv = ctx.dotenv;
-        const sources2 = await resolveGetDotenvConfigSources(import.meta.url);
-        const issues = validateEnvAgainstSources(dotenv, sources2);
-        if (Array.isArray(issues) && issues.length > 0) {
-          const logger = (merged as unknown as GetDotenvCliOptions).logger;
-          issues.forEach((m) => {
-            logger.error(m);
-          });
-          if ((merged as unknown as GetDotenvCliOptions).strict)
-            process.exit(1);
-        }
-      } catch {
-        /* tolerate non-strict flows */
-      }
+    } catch {
+      /* tolerate non-strict flows */
     }
   });
   return program;


### PR DESCRIPTION
preAction unconditionally overwrites the options bag with a fresh merge from CLI options. When a subcommand flow has already resolved context via preSubcommand, hasCtx() is true and the propagateResolvedEnv call inside the if-block never executes — leaving bag.env undefined for downstream plugins.

This caused aws-cognito-tools and aws-api-gateway-tools plugin commands to fail with env is required when invoked as subcommands without an explicit env flag, even though defaultEnv was configured.

Fix: move propagateResolvedEnv, help-text refresh, and env validation outside the hasCtx guard.

Closes #21