### PR TITLE
feat: add JSON Schema for config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
   "files": [
     "dist",
     "getdotenv.config.json",
+    "schema",
     "templates"
   ],
   "homepage": "https://github.com/karmaniverous/get-dotenv#readme",
@@ -200,7 +201,8 @@
     "url": "https://github.com/karmaniverous/get-dotenv"
   },
   "scripts": {
-    "build": "rimraf dist && rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
+    "generate:schema": "tsx tools/generate-schema.js",
+    "build": "npm run generate:schema && rimraf dist && rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "cli": "tsx src/cli/getdotenv",
     "cli:dist": "node dist/getdotenv.cli.mjs",
     "changelog": "auto-changelog",

--- a/schema/getdotenv.config.schema.json
+++ b/schema/getdotenv.config.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "rootOptionDefaults": {
+      "type": "object",
+      "properties": {
+        "defaultEnv": {
+          "type": "string"
+        },
+        "defaultEnvKey": {
+          "type": "string"
+        },
+        "dotenvToken": {
+          "type": "string"
+        },
+        "dynamicPath": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "env": {
+          "type": "string"
+        },
+        "excludeDynamic": {
+          "type": "boolean"
+        },
+        "excludeEnv": {
+          "type": "boolean"
+        },
+        "excludeGlobal": {
+          "type": "boolean"
+        },
+        "excludePrivate": {
+          "type": "boolean"
+        },
+        "excludePublic": {
+          "type": "boolean"
+        },
+        "loadProcess": {
+          "type": "boolean"
+        },
+        "log": {
+          "type": "boolean"
+        },
+        "outputPath": {
+          "type": "string"
+        },
+        "paths": {
+          "type": "string"
+        },
+        "privateToken": {
+          "type": "string"
+        },
+        "vars": {
+          "type": "string"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "capture": {
+          "type": "boolean"
+        },
+        "trace": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "redact": {
+          "type": "boolean"
+        },
+        "warnEntropy": {
+          "type": "boolean"
+        },
+        "entropyThreshold": {
+          "type": "number"
+        },
+        "entropyMinLength": {
+          "type": "number"
+        },
+        "entropyWhitelist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "redactPatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "pathsDelimiter": {
+          "type": "string"
+        },
+        "pathsDelimiterPattern": {
+          "type": "string"
+        },
+        "scripts": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {}
+        },
+        "shell": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "varsAssignor": {
+          "type": "string"
+        },
+        "varsAssignorPattern": {
+          "type": "string"
+        },
+        "varsDelimiter": {
+          "type": "string"
+        },
+        "varsDelimiterPattern": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "rootOptionVisibility": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "scripts": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    },
+    "requiredKeys": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "schema": {},
+    "vars": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "envVars": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "propertyNames": {
+          "type": "string"
+        },
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    },
+    "dynamic": {},
+    "plugins": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
+    }
+  },
+  "additionalProperties": false,
+  "$id": "https://raw.githubusercontent.com/karmaniverous/get-dotenv/main/schema/getdotenv.config.schema.json",
+  "title": "get-dotenv Configuration",
+  "description": "Schema for getdotenv.config.json configuration files. See https://github.com/karmaniverous/get-dotenv"
+}

--- a/tools/generate-schema.js
+++ b/tools/generate-schema.js
@@ -1,0 +1,56 @@
+/**
+ * Generate a JSON Schema from the Zod config schema for IDE IntelliSense.
+ *
+ * Usage: tsx tools/generate-schema.js
+ *
+ * Outputs: schema/getdotenv.config.schema.json
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { z } from 'zod';
+
+// tsx resolves TypeScript path aliases, so we can import directly.
+// eslint picks up this file as .js (not .ts), avoiding tsconfig project issues.
+import { getDotenvCliOptionsSchemaRaw } from '../src/schema/getDotenvCliOptions.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+
+// Rebuild the config schema with `logger` omitted — it is a runtime-only
+// field (defaults to `console`) that has no meaning in JSON/YAML configs.
+const cliOptionsForConfig = getDotenvCliOptionsSchemaRaw.omit({ logger: true });
+
+const configSchema = z.object({
+  rootOptionDefaults: cliOptionsForConfig.optional(),
+  rootOptionVisibility: z.record(z.string(), z.boolean()).optional(),
+  scripts: z.record(z.string(), z.unknown()).optional(),
+  requiredKeys: z.array(z.string()).optional(),
+  schema: z.unknown().optional(),
+  vars: z.record(z.string(), z.string()).optional(),
+  envVars: z.record(z.string(), z.record(z.string(), z.string())).optional(),
+  dynamic: z.unknown().optional(),
+  plugins: z.record(z.string(), z.unknown()).optional(),
+});
+
+const jsonSchema = z.toJSONSchema(configSchema, {
+  target: 'draft-2020-12',
+});
+
+// Augment with metadata
+const output = {
+  ...jsonSchema,
+  $id: 'https://raw.githubusercontent.com/karmaniverous/get-dotenv/main/schema/getdotenv.config.schema.json',
+  title: 'get-dotenv Configuration',
+  description:
+    'Schema for getdotenv.config.json configuration files. See https://github.com/karmaniverous/get-dotenv',
+};
+
+const outDir = path.join(rootDir, 'schema');
+fs.mkdirSync(outDir, { recursive: true });
+
+const outPath = path.join(outDir, 'getdotenv.config.schema.json');
+fs.writeFileSync(outPath, JSON.stringify(output, null, 2) + '\n');
+
+console.log(`✅ JSON Schema written to ${path.relative(rootDir, outPath)}`);


### PR DESCRIPTION
Closes #12

Generates a JSON Schema from the existing Zod config schemas and ships it in the published package. IDEs can reference it via `$schema` for IntelliSense on `getdotenv.config.json` files.

## What's included

- **`tools/generate-schema.js`** — Build-time script that uses Zod v4's native `z.toJSONSchema()` to convert `getDotenvConfigSchemaRaw` (with the runtime-only `logger` field omitted) into a JSON Schema (Draft 2020-12).
- **`schema/getdotenv.config.schema.json`** — The generated schema, included in the published package via the `files` array.
- **`generate:schema` npm script** — Wired into the `build` script so the schema is regenerated on every build.

## Usage

In any `getdotenv.config.json` file:

```json
{
  "$schema": "https://raw.githubusercontent.com/karmaniverous/get-dotenv/main/schema/getdotenv.config.schema.json",
  "vars": { }
}
```

Or reference the local copy from `node_modules`:

```json
{
  "$schema": "./node_modules/@karmaniverous/get-dotenv/schema/getdotenv.config.schema.json"
}
```
