### PR TITLE
fix(core): scope afterResolve to invoked command branch within groups

### DIFF
--- a/src/cliHost/GetDotenvCli.ts
+++ b/src/cliHost/GetDotenvCli.ts
@@ -140,7 +140,10 @@ export class GetDotenvCli<
     // Ensure plugins are installed exactly once, then run afterResolve.
     await this.install();
     if (opts?.runAfterResolve ?? true) {
-      await this._runAfterResolve(ctx, opts?.invokedSubcommand);
+      const path = opts?.invokedSubcommand
+        ? [opts.invokedSubcommand]
+        : undefined;
+      await this._runAfterResolve(ctx, path);
     }
 
     return ctx;
@@ -363,19 +366,52 @@ export class GetDotenvCli<
 
   /**
    * Run afterResolve hooks for registered plugins (parent → children).
-   * When {@link invokedSubcommand} is provided, only the matching plugin
-   * subtree runs; otherwise all plugins run (backward compatibility).
+   * When {@link commandPath} is provided, only the matching branch of the
+   * plugin tree runs; otherwise all plugins run (backward compatibility).
+   *
+   * The path is walked segment-by-segment against the plugin tree.
+   * Intermediate matches run their own afterResolve hook.
+   * The deepest match runs afterResolve for itself and all its descendants.
    */
-  private async _runAfterResolve(
+  async _runAfterResolve(
     ctx: GetDotenvCliCtx<TOptions>,
-    invokedSubcommand?: string,
+    commandPath?: string[],
   ): Promise<void> {
-    const plugins = invokedSubcommand
-      ? this._plugins
-          .filter((e) => effectiveNs(e) === invokedSubcommand)
-          .map((e) => e.plugin)
-      : this._plugins.map((e) => e.plugin);
+    if (!commandPath || commandPath.length === 0) {
+      await runAfterResolveTree(
+        this,
+        this._plugins.map((e) => e.plugin),
+        ctx,
+      );
+      return;
+    }
 
-    await runAfterResolveTree(this, plugins, ctx);
+    // Walk the plugin tree along the command path, scoping to the invoked branch.
+    let entries: Array<PluginChildEntry<TOptions, TArgs, TOpts, TGlobal>> =
+      this._plugins;
+
+    for (let i = 0; i < commandPath.length; i++) {
+      const segment = commandPath[i] as string;
+      const entry = entries.find((e) => effectiveNs(e) === segment);
+      if (!entry) return;
+
+      const isLast = i === commandPath.length - 1;
+      const nextSegment = commandPath[i + 1];
+      const hasMatchingChild =
+        !isLast &&
+        entry.plugin.children.some((e) => effectiveNs(e) === nextSegment);
+
+      if (isLast || !hasMatchingChild) {
+        // Deepest match: run this plugin + all its descendants.
+        await runAfterResolveTree(this, [entry.plugin], ctx);
+        return;
+      }
+
+      // Intermediate match: run only this plugin's own afterResolve.
+      if (entry.plugin.afterResolve) {
+        await entry.plugin.afterResolve(this, ctx);
+      }
+      entries = entry.plugin.children;
+    }
   }
 }

--- a/src/cliHost/groupPlugins.scope.test.ts
+++ b/src/cliHost/groupPlugins.scope.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Prevent actual process spawning.
+const runCommandMock =
+  vi.fn<
+    (
+      cmd: string | string[],
+      shell: string | boolean | URL,
+      opts: { env?: Record<string, string>; stdio?: 'inherit' | 'pipe' },
+    ) => Promise<number>
+  >();
+vi.mock('./exec', () => ({
+  shouldCapture: () => true,
+  runCommand: (
+    cmd: string | string[],
+    shell: string | boolean | URL,
+    opts: { env?: Record<string, string>; stdio?: 'inherit' | 'pipe' },
+  ) => runCommandMock(cmd, shell, opts),
+}));
+
+import { createCli } from '@/src/cli';
+import { definePlugin } from '@/src/cliHost';
+
+import { groupPlugins } from './groupPlugins';
+
+describe('groupPlugins afterResolve scoping', () => {
+  const fired: string[] = [];
+
+  beforeEach(() => {
+    fired.length = 0;
+    runCommandMock.mockReset().mockResolvedValue(0);
+  });
+
+  /**
+   * Helper: create a plugin with an afterResolve spy and a simple echo action.
+   */
+  function spyPlugin(ns: string) {
+    return definePlugin({
+      ns,
+      setup(cli) {
+        cli.description(`${ns} plugin`);
+        cli
+          .command('echo')
+          .argument('[words...]')
+          .action(() => {
+            /* no-op action */
+          });
+      },
+      afterResolve() {
+        fired.push(ns);
+      },
+    });
+  }
+
+  it('invoking tools alpha echo → only alpha afterResolve fires', async () => {
+    const run = createCli({
+      alias: 'test',
+      compose: (program) =>
+        program.use(
+          groupPlugins({ ns: 'tools' })
+            .use(spyPlugin('alpha'))
+            .use(spyPlugin('beta')),
+        ),
+    });
+
+    await run(['node', 'test', 'tools', 'alpha', 'echo', 'hello']);
+
+    expect(fired).toContain('alpha');
+    expect(fired).not.toContain('beta');
+  });
+
+  it('invoking tools beta echo → only beta afterResolve fires', async () => {
+    const run = createCli({
+      alias: 'test',
+      compose: (program) =>
+        program.use(
+          groupPlugins({ ns: 'tools' })
+            .use(spyPlugin('alpha'))
+            .use(spyPlugin('beta')),
+        ),
+    });
+
+    await run(['node', 'test', 'tools', 'beta', 'echo', 'hello']);
+
+    expect(fired).toContain('beta');
+    expect(fired).not.toContain('alpha');
+  });
+
+  it('group afterResolve fires for any child in the group', async () => {
+    const groupPlugin = groupPlugins({
+      ns: 'tools',
+    });
+    // Attach afterResolve to the group plugin itself.
+    groupPlugin.afterResolve = () => {
+      fired.push('tools-group');
+    };
+    groupPlugin.use(spyPlugin('alpha')).use(spyPlugin('beta'));
+
+    const run = createCli({
+      alias: 'test',
+      compose: (program) => program.use(groupPlugin),
+    });
+
+    await run(['node', 'test', 'tools', 'alpha', 'echo', 'hi']);
+
+    expect(fired).toContain('tools-group');
+    expect(fired).toContain('alpha');
+    expect(fired).not.toContain('beta');
+  });
+});

--- a/src/cliHost/rootHooks.ts
+++ b/src/cliHost/rootHooks.ts
@@ -82,7 +82,7 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
   };
 
   // Hook: preSubcommand — always runs for subcommand flows.
-  program.hook('preSubcommand', async (thisCommand, actionCommand) => {
+  program.hook('preSubcommand', async (thisCommand, _actionCommand) => {
     const sources = await resolveGetDotenvConfigSources(import.meta.url);
     const rawArgs =
       (thisCommand as unknown as { rawArgs?: string[] }).rawArgs ?? [];
@@ -122,11 +122,12 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
     )._setOptionsBag(merged as unknown as GetDotenvCliOptions);
 
     // Resolve context for this run via programmatic converter.
+    // afterResolve is deferred to preAction where the full command path is known.
     const serviceOptions = getDotenvCliOptions2Options(
       merged,
     ) as unknown as Partial<TOptions>;
     await program.resolveAndLoad(serviceOptions, {
-      invokedSubcommand: actionCommand.name(),
+      runAfterResolve: false,
     });
 
     propagateResolvedEnv(merged);
@@ -158,8 +159,8 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
     }
   });
 
-  // Hook: preAction — root-only and parent-alias flows.
-  program.hook('preAction', async (thisCommand) => {
+  // Hook: preAction — root-only and parent-alias flows + scoped afterResolve.
+  program.hook('preAction', async (thisCommand, actionCommand) => {
     const sources = await resolveGetDotenvConfigSources(import.meta.url);
     const rawArgs =
       (thisCommand as unknown as { rawArgs?: string[] }).rawArgs ?? [];
@@ -228,6 +229,26 @@ export function installRootHooks<TOptions extends GetDotenvOptions>(
       }
     } catch {
       /* tolerate non-strict flows */
+    }
+
+    // Run afterResolve scoped to the invoked command branch.
+    // Walk actionCommand.parent chain to build the full plugin path.
+    // Always true after resolution above, but satisfies the type checker.
+    const ctx = program.hasCtx() ? program.getCtx() : undefined;
+    if (ctx) {
+      const segments: string[] = [];
+      let node: { name: () => string; parent?: unknown } | undefined =
+        actionCommand;
+      while (node && node !== (thisCommand as unknown)) {
+        segments.unshift(node.name());
+        node = (node as { parent?: { name: () => string; parent?: unknown } })
+          .parent;
+      }
+      await (
+        program as unknown as {
+          _runAfterResolve: (c: typeof ctx, p?: string[]) => Promise<void>;
+        }
+      )._runAfterResolve(ctx, segments.length > 0 ? segments : undefined);
     }
   });
   return program;


### PR DESCRIPTION
Closes #25

Moves afterResolve execution from preSubcommand to preAction where Commander provides the actual leaf actionCommand. Walks the command ancestry to scope afterResolve to just the invoked branch of the plugin tree.