### PR TITLE
feat(batch): add parallel execution option

### DIFF
--- a/src/plugins/batch/cmdAction.ts
+++ b/src/plugins/batch/cmdAction.ts
@@ -53,6 +53,8 @@ export const attachBatchCmdAction = (
         list?: boolean;
         ignoreErrors?: boolean;
         globs?: string;
+        parallel?: boolean;
+        concurrency?: number;
         pkgCwd?: boolean;
         rootPath?: string;
         command?: string;
@@ -72,6 +74,10 @@ export const attachBatchCmdAction = (
           : typeof cfg.rootPath === 'string'
             ? cfg.rootPath
             : './';
+      const parallel =
+        g.parallel !== undefined ? g.parallel : Boolean(cfg.parallel);
+      const concurrency =
+        typeof g.concurrency === 'number' ? g.concurrency : cfg.concurrency;
 
       // Resolve scripts/shell with precedence:
       // plugin opts → plugin config → merged root CLI options
@@ -86,11 +92,13 @@ export const attachBatchCmdAction = (
         if (typeof commandOpt === 'string') {
           await execShellCommandBatch({
             command: resolveCommand(scripts, commandOpt),
+            ...(concurrency !== undefined ? { concurrency } : {}),
             dotenvEnv,
             globs,
             ignoreErrors,
             list: false,
             logger,
+            parallel,
             ...(pkgCwd ? { pkgCwd } : {}),
             rootPath,
             shell: resolveShell(scripts, commandOpt, shell),
@@ -107,10 +115,12 @@ export const attachBatchCmdAction = (
                 ? rootShell
                 : false;
           await execShellCommandBatch({
+            ...(concurrency !== undefined ? { concurrency } : {}),
             globs,
             ignoreErrors,
             list: true,
             logger,
+            parallel,
             ...(pkgCwd ? { pkgCwd } : {}),
             rootPath,
             shell: listShell,
@@ -154,12 +164,14 @@ export const attachBatchCmdAction = (
 
       await execShellCommandBatch({
         command: commandArg,
+        ...(concurrency !== undefined ? { concurrency } : {}),
         dotenvEnv,
         ...(envBag ? { getDotenvCliOptions: envBag } : {}),
         globs,
         ignoreErrors,
         list: false,
         logger,
+        parallel,
         ...(pkgCwd ? { pkgCwd } : {}),
         rootPath,
         shell: shellSetting,

--- a/src/plugins/batch/defaultAction.ts
+++ b/src/plugins/batch/defaultAction.ts
@@ -44,6 +44,10 @@ export const attachBatchDefaultAction = (
     let globs =
       typeof opts.globs === 'string' ? opts.globs : (cfg.globs ?? '*');
     const list = Boolean(opts.list);
+    const parallel =
+      opts.parallel !== undefined ? opts.parallel : Boolean(cfg.parallel);
+    const concurrency =
+      typeof opts.concurrency === 'number' ? opts.concurrency : cfg.concurrency;
     const pkgCwd =
       opts.pkgCwd !== undefined ? opts.pkgCwd : Boolean(cfg.pkgCwd);
     const rootPath =
@@ -72,11 +76,13 @@ export const attachBatchDefaultAction = (
 
       await execShellCommandBatch({
         command: commandArg,
+        ...(concurrency !== undefined ? { concurrency } : {}),
         dotenvEnv,
         globs,
         ignoreErrors,
         list: false,
         logger,
+        parallel,
         ...(pkgCwd ? { pkgCwd } : {}),
         rootPath,
         shell: shellSetting,
@@ -92,10 +98,12 @@ export const attachBatchDefaultAction = (
         pluginOpts.shell ?? cfg.shell ?? merged.shell ?? false;
 
       await execShellCommandBatch({
+        ...(concurrency !== undefined ? { concurrency } : {}),
         globs,
         ignoreErrors,
         list: true,
         logger,
+        parallel,
         ...(pkgCwd ? { pkgCwd } : {}),
         rootPath,
         shell: shellMerged,
@@ -115,11 +123,13 @@ export const attachBatchDefaultAction = (
 
       await execShellCommandBatch({
         command: resolveCommand(scriptsOpt, commandOpt),
+        ...(concurrency !== undefined ? { concurrency } : {}),
         dotenvEnv,
         globs,
         ignoreErrors,
         list,
         logger,
+        parallel,
         ...(pkgCwd ? { pkgCwd } : {}),
         rootPath,
         shell: resolveShell(scriptsOpt, commandOpt, shellOpt),
@@ -132,10 +142,12 @@ export const attachBatchDefaultAction = (
     const shellOnly = pluginOpts.shell ?? cfg.shell ?? merged.shell ?? false;
 
     await execShellCommandBatch({
+      ...(concurrency !== undefined ? { concurrency } : {}),
       globs,
       ignoreErrors,
       list: true,
       logger,
+      parallel,
       ...(pkgCwd ? { pkgCwd } : {}),
       rootPath,
       shell: shellOnly,

--- a/src/plugins/batch/execShellCommandBatch.ts
+++ b/src/plugins/batch/execShellCommandBatch.ts
@@ -2,12 +2,18 @@ import { globby } from 'globby';
 import { packageDirectory } from 'package-directory';
 import path from 'path';
 
-import { buildSpawnEnv, composeNestedEnv, runCommand } from '@/src/cliHost';
+import {
+  buildSpawnEnv,
+  composeNestedEnv,
+  runCommand,
+  runCommandResult,
+} from '@/src/cliHost';
 
 import type {
   BatchGlobPathsOptions,
   ExecShellCommandBatchOptions,
 } from './types';
+import { defaultConcurrency } from './types';
 
 const globPaths = async ({
   globs,
@@ -47,18 +53,29 @@ const globPaths = async ({
   return { absRootPath, paths };
 };
 
+/** Result of a single parallel directory execution. */
+interface ParallelResult {
+  dirPath: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  error?: unknown;
+}
+
 /**
  * Execute a batch of commands across multiple directories.
  * Discovers targets via globs/rootPath and runs the command in each.
  */
 export const execShellCommandBatch = async ({
   command,
+  concurrency,
   getDotenvCliOptions,
   dotenvEnv,
   globs,
   ignoreErrors,
   list,
   logger,
+  parallel,
   pkgCwd,
   rootPath,
   shell,
@@ -84,7 +101,9 @@ export const execShellCommandBatch = async ({
 
   const headerTitle = list
     ? 'Listing working directories...'
-    : 'Executing command batch...';
+    : parallel
+      ? 'Executing command batch (parallel)...'
+      : 'Executing command batch...';
   logger.info('');
   const headerRootPath = `ROOT:  ${absRootPath}`;
   const headerGlobs = `GLOBS: ${globs}`;
@@ -112,45 +131,151 @@ export const execShellCommandBatch = async ({
   logger.info(headerGlobs);
   logger.info(headerCommand);
 
-  for (const path of paths) {
-    // Write path and command to console.
-    const pathLabel = `CWD:   ${path}`;
+  // List mode: no parallelism needed.
+  if (list) {
+    for (const p of paths) {
+      logger.info(`CWD:   ${p}`);
+    }
+    logger.info('');
+    return;
+  }
 
-    if (list) {
+  // Narrow command to a non-empty string or array after validation.
+  const validCommand: string | string[] | undefined =
+    typeof command === 'string' && command.length > 0
+      ? command
+      : Array.isArray(command) && command.length > 0
+        ? command
+        : undefined;
+
+  if (!validCommand) {
+    logger.error(`No command provided. Use --command or --list.`);
+    process.exit(0);
+  }
+
+  // Compose child env overlay once (shared across all paths).
+  const overlay = composeNestedEnv(getDotenvCliOptions ?? {}, dotenvEnv ?? {});
+  const spawnEnv = buildSpawnEnv(process.env, overlay);
+
+  if (parallel) {
+    // Parallel execution with concurrency-limited pool.
+    const limit = concurrency ?? defaultConcurrency;
+    const results: ParallelResult[] = [];
+
+    // Simple semaphore-based concurrency pool.
+    let active = 0;
+    let nextIdx = 0;
+    const total = paths.length;
+    results.length = total;
+
+    await new Promise<void>((resolveAll, rejectAll) => {
+      let settled = false;
+      let completedCount = 0;
+
+      const tryLaunch = () => {
+        while (active < limit && nextIdx < total) {
+          const idx = nextIdx++;
+          const dirPath = paths[idx] as string;
+          active++;
+
+          runCommandResult(validCommand, shell, {
+            cwd: dirPath,
+            env: spawnEnv,
+          })
+            .then((res) => {
+              results[idx] = {
+                dirPath,
+                exitCode: res.exitCode,
+                stdout: res.stdout,
+                stderr: res.stderr,
+              };
+            })
+            .catch((err: unknown) => {
+              results[idx] = {
+                dirPath,
+                exitCode: 1,
+                stdout: '',
+                stderr: String(err),
+                error: err,
+              };
+            })
+            .finally(() => {
+              active--;
+              completedCount++;
+              if (completedCount === total && !settled) {
+                settled = true;
+                resolveAll();
+              } else {
+                tryLaunch();
+              }
+            });
+        }
+      };
+
+      if (total === 0) {
+        resolveAll();
+      } else {
+        tryLaunch();
+      }
+
+      // Safety: if rejectAll is never called, the promise resolves via completedCount.
+      void rejectAll;
+    });
+
+    // Print results in discovery order.
+    const failures: ParallelResult[] = [];
+
+    for (const result of results) {
+      const pathLabel = `CWD:   ${result.dirPath}`;
+      logger.info('');
+      logger.info('*'.repeat(pathLabel.length));
       logger.info(pathLabel);
-      continue;
+      logger.info(headerCommand);
+
+      if (result.stdout) {
+        process.stdout.write(
+          result.stdout + (result.stdout.endsWith('\n') ? '' : '\n'),
+        );
+      }
+      if (result.stderr) {
+        process.stderr.write(
+          result.stderr + (result.stderr.endsWith('\n') ? '' : '\n'),
+        );
+      }
+
+      if (result.exitCode !== 0) {
+        failures.push(result);
+      }
     }
 
-    logger.info('');
-    logger.info('*'.repeat(pathLabel.length));
-    logger.info(pathLabel);
-    logger.info(headerCommand);
+    if (failures.length > 0 && !ignoreErrors) {
+      logger.error('');
+      logger.error(
+        `${String(failures.length)} of ${String(total)} directories failed:`,
+      );
+      for (const f of failures) {
+        logger.error(`  ${f.dirPath} (exit code ${String(f.exitCode)})`);
+      }
+    }
+  } else {
+    // Sequential execution (original behavior).
+    for (const p of paths) {
+      const pathLabel = `CWD:   ${p}`;
+      logger.info('');
+      logger.info('*'.repeat(pathLabel.length));
+      logger.info(pathLabel);
+      logger.info(headerCommand);
 
-    // Execute command.
-    try {
-      const hasCmd =
-        (typeof command === 'string' && command.length > 0) ||
-        (Array.isArray(command) && command.length > 0);
-      if (hasCmd) {
-        // Compose child env overlay (dotenv + nested bag)
-        const overlay = composeNestedEnv(
-          getDotenvCliOptions ?? {},
-          dotenvEnv ?? {},
-        );
-
-        await runCommand(command, shell, {
-          cwd: path,
-          env: buildSpawnEnv(process.env, overlay),
+      try {
+        await runCommand(validCommand, shell, {
+          cwd: p,
+          env: spawnEnv,
           stdio: capture ? 'pipe' : 'inherit',
         });
-      } else {
-        // Should not occur due to the early guard; retain for type safety.
-        logger.error(`No command provided. Use --command or --list.`);
-        process.exit(0);
-      }
-    } catch (error) {
-      if (!ignoreErrors) {
-        throw error;
+      } catch (error) {
+        if (!ignoreErrors) {
+          throw error;
+        }
       }
     }
   }

--- a/src/plugins/batch/index.test.ts
+++ b/src/plugins/batch/index.test.ts
@@ -133,4 +133,62 @@ describe('plugins/batch', () => {
     expect(args.command).toBe('echo OK');
     expect(args.list).toBe(false);
   });
+
+  it('propagates parallel flag', async () => {
+    const run = createCli({
+      alias: 'test',
+      compose: (p) => p.use(batchPlugin()),
+    });
+
+    await run(['node', 'test', 'batch', '--command', 'echo ok', '--parallel']);
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const firstCall = execMock.mock.calls[0] as
+      | [Record<string, unknown>]
+      | undefined;
+    const [args] = firstCall as [Record<string, unknown>];
+    expect(args.parallel).toBe(true);
+  });
+
+  it('propagates concurrency flag', async () => {
+    const run = createCli({
+      alias: 'test',
+      compose: (p) => p.use(batchPlugin()),
+    });
+
+    await run([
+      'node',
+      'test',
+      'batch',
+      '--command',
+      'echo ok',
+      '--parallel',
+      '--concurrency',
+      '4',
+    ]);
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const firstCall = execMock.mock.calls[0] as
+      | [Record<string, unknown>]
+      | undefined;
+    const [args] = firstCall as [Record<string, unknown>];
+    expect(args.parallel).toBe(true);
+    expect(args.concurrency).toBe(4);
+  });
+
+  it('defaults parallel to false when not specified', async () => {
+    const run = createCli({
+      alias: 'test',
+      compose: (p) => p.use(batchPlugin()),
+    });
+
+    await run(['node', 'test', 'batch', '--command', 'echo ok']);
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const firstCall = execMock.mock.calls[0] as
+      | [Record<string, unknown>]
+      | undefined;
+    const [args] = firstCall as [Record<string, unknown>];
+    expect(args.parallel).toBe(false);
+  });
 });

--- a/src/plugins/batch/options.ts
+++ b/src/plugins/batch/options.ts
@@ -3,7 +3,7 @@ import type { Command, OptionValues } from '@commander-js/extra-typings';
 import type { GetDotenvCliPublic } from '@/src/cliHost';
 
 import type { BatchPlugin } from '.';
-import type { BatchPluginConfig } from './types';
+import { type BatchPluginConfig, defaultConcurrency } from './types';
 
 /**
  * Option values parsed for the `batch` command mount.
@@ -35,6 +35,14 @@ export interface BatchCommandOptionValues extends OptionValues {
    * When true, ignore errors and continue with the next matched directory.
    */
   ignoreErrors?: boolean;
+  /**
+   * When true, execute commands in parallel across discovered directories.
+   */
+  parallel?: boolean;
+  /**
+   * Maximum number of concurrent executions in parallel mode.
+   */
+  concurrency?: number;
 }
 
 /**
@@ -122,6 +130,20 @@ export function attachBatchOptions(
       .option(
         '-e, --ignore-errors',
         'ignore errors and continue with next path',
+      )
+      .option(
+        '-P, --parallel',
+        'execute commands in parallel across directories',
+      )
+      .option(
+        '-C, --concurrency <n>',
+        `max concurrent executions in parallel mode (default: ${String(defaultConcurrency)})`,
+        (v: string) => {
+          const n = Number.parseInt(v, 10);
+          if (Number.isNaN(n) || n < 1)
+            throw new Error(`invalid concurrency: ${v}`);
+          return n;
+        },
       )
       .argument('[command...]')
   );

--- a/src/plugins/batch/types.ts
+++ b/src/plugins/batch/types.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import { z } from 'zod';
 
 import type { ScriptsTable } from '@/src/cliHost';
@@ -5,6 +6,15 @@ import type { Logger, ProcessEnv } from '@/src/core';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { execShellCommandBatch } from './execShellCommandBatch';
+
+/**
+ * Default concurrency limit for parallel batch execution.
+ * Uses `os.availableParallelism()` when available, otherwise falls back to CPU count.
+ */
+export const defaultConcurrency: number =
+  typeof os.availableParallelism === 'function'
+    ? os.availableParallelism()
+    : os.cpus().length;
 
 /**
  * Options provided to the batch plugin factory.
@@ -62,6 +72,11 @@ export interface ExecShellCommandBatchOptions {
    */
   command?: string | string[];
   /**
+   * Maximum number of concurrent executions when {@link ExecShellCommandBatchOptions.parallel} is true.
+   * Defaults to {@link defaultConcurrency}.
+   */
+  concurrency?: number;
+  /**
    * Merged root CLI options bag (JSON‑serializable) forwarded for nested composition
    * by downstream executors. Used to compute child overlays deterministically.
    */
@@ -87,6 +102,11 @@ export interface ExecShellCommandBatchOptions {
    */
   logger: Logger;
   /**
+   * When true, execute commands across discovered directories in parallel.
+   * Output is buffered per-directory and printed in discovery order.
+   */
+  parallel?: boolean;
+  /**
    * Resolve the batch root from the nearest package directory instead of CWD.
    */
   pkgCwd?: boolean;
@@ -109,12 +129,16 @@ export interface ExecShellCommandBatchOptions {
 export interface BatchParentInvokerFlags {
   /** Command to execute. */
   command?: string;
+  /** Maximum concurrent executions in parallel mode. */
+  concurrency?: number;
   /** Space-delimited glob patterns. */
   globs?: string;
   /** List directories without executing. */
   list?: boolean;
   /** Ignore errors and continue. */
   ignoreErrors?: boolean;
+  /** Execute commands in parallel across directories. */
+  parallel?: boolean;
   /** Use package directory as root. */
   pkgCwd?: boolean;
   /** Root path for discovery. */
@@ -147,6 +171,8 @@ export const ScriptSchema = z.union([
  * Zod schema for batch plugin configuration.
  */
 export const batchPluginConfigSchema = z.object({
+  /** Maximum concurrent executions in parallel mode. */
+  concurrency: z.number().int().positive().optional(),
   /** Optional scripts table scoped to the batch plugin. */
   scripts: z.record(z.string(), ScriptSchema).optional(),
   /** Optional default shell for batch execution (overridden by per-script shell when present). */
@@ -155,6 +181,8 @@ export const batchPluginConfigSchema = z.object({
   rootPath: z.string().optional(),
   /** Space-delimited glob patterns used to discover directories. */
   globs: z.string().optional(),
+  /** Execute commands in parallel across discovered directories. */
+  parallel: z.boolean().optional(),
   /** When true, resolve the batch root from the nearest package directory. */
   pkgCwd: z.boolean().optional(),
 });


### PR DESCRIPTION
Closes #7

Adds --parallel (-P) and --concurrency (-C) flags to the batch command for concurrent execution across discovered directories. Output is buffered per-directory and printed in discovery order.

## Summary
- Add `--parallel` / `-P` boolean flag (default: false) to execute batch commands concurrently
- Add `--concurrency` / `-C` flag (default: `os.availableParallelism()`) to limit parallel workers
- Parallel mode buffers stdout/stderr per-directory and prints results in discovery order
- Error handling: collects all results and reports failures by directory
- Sequential mode behavior is completely unchanged
- No new dependencies — uses a simple semaphore-based concurrency pool

## Test plan
- [x] New test: propagates `--parallel` flag
- [x] New test: propagates `--concurrency` flag  
- [x] New test: defaults `parallel` to false when not specified
- [x] All existing tests continue to pass
- [x] `npm run lint` — zero new errors
- [x] `npm run build` — succeeds
- [x] `npm run test` — all 227 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)