### PR TITLE
feat: dynamic null deletes key, undefined is no-op

### DIFF
--- a/src/cliHost/dotenvProvenance.dynamic.test.ts
+++ b/src/cliHost/dotenvProvenance.dynamic.test.ts
@@ -110,7 +110,7 @@ describe('cliHost dotenvProvenance (dynamic precedence)', () => {
     await fs.remove(dir);
   });
 
-  it('records op=unset when a dynamic function returns undefined', async () => {
+  it('records op=unset when a dynamic function returns null', async () => {
     const dir = path.join(ROOT, 'case-unset');
     await fs.remove(dir);
     await fs.ensureDir(dir);
@@ -128,11 +128,11 @@ describe('cliHost dotenvProvenance (dynamic precedence)', () => {
         log: false,
         loadProcess: false,
         dynamic: {
-          PROV_UNSET: () => undefined,
+          PROV_UNSET: () => null,
         },
       });
 
-      expect(ctx.dotenv.PROV_UNSET).toBeUndefined();
+      expect('PROV_UNSET' in ctx.dotenv).toBe(false);
 
       const hist = ctx.dotenvProvenance.PROV_UNSET ?? [];
       const dyn = hist.filter(isDynamicProvEntry);
@@ -141,6 +141,40 @@ describe('cliHost dotenvProvenance (dynamic precedence)', () => {
       const last = dyn[dyn.length - 1];
       expect(last?.dynamicSource).toBe('programmatic');
       expect(last?.op).toBe('unset');
+    });
+
+    await fs.remove(dir);
+  });
+
+  it('records no provenance when a dynamic function returns undefined', async () => {
+    const dir = path.join(ROOT, 'case-noop');
+    await fs.remove(dir);
+    await fs.ensureDir(dir);
+
+    await writeJson(path.join(dir, 'package.json'), {
+      name: 'dotenv-provenance-dynamic-tests',
+      type: 'module',
+    });
+
+    const cli = new GetDotenvCli('test');
+
+    await withCwd(dir, async () => {
+      const ctx = await cli.resolveAndLoad({
+        paths: [],
+        log: false,
+        loadProcess: false,
+        dynamic: {
+          PROV_NOOP: () => undefined,
+        },
+      });
+
+      // undefined is a no-op: key should not exist
+      expect('PROV_NOOP' in ctx.dotenv).toBe(false);
+
+      // No provenance entry should be recorded for undefined
+      const hist = ctx.dotenvProvenance.PROV_NOOP ?? [];
+      const dyn = hist.filter(isDynamicProvEntry);
+      expect(dyn.length).toBe(0);
     });
 
     await fs.remove(dir);

--- a/src/core/GetDotenvOptions.infer.ts
+++ b/src/core/GetDotenvOptions.infer.ts
@@ -24,7 +24,7 @@ const _fn: DynamicFn<Vars> = dynamic.GREETING;
 const _tag: string = dynamic.TAG;
 
 // Ensure DynamicFn arg types line up (APP/ENV from Vars)
-const _exampleCall: string | undefined = _fn({ APP: 'world' }, 'dev');
+const _exampleCall: string | null | undefined = _fn({ APP: 'world' }, 'dev');
 void _exampleCall;
 void _fn;
 void _tag;

--- a/src/core/GetDotenvOptions.ts
+++ b/src/core/GetDotenvOptions.ts
@@ -61,7 +61,7 @@ export type RootOptionsShapeCompat = Omit<
 export type GetDotenvDynamicFunction = (
   vars: ProcessEnv,
   env: string | undefined,
-) => string | undefined;
+) => string | null | undefined;
 
 /**
  * A map of dynamic variable definitions.
@@ -126,7 +126,7 @@ export type GetDotenvOptions = Omit<
 export type DynamicFn<Vars extends ProcessEnv> = (
   vars: Vars,
   env?: string,
-) => string | undefined;
+) => string | null | undefined;
 
 /**
  * Vars-aware dynamic map type used by {@link defineDynamic} and JS/TS configs.

--- a/src/core/getDotenv.dynamic.nulldelete.test.ts
+++ b/src/core/getDotenv.dynamic.nulldelete.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDotenv } from './getDotenv';
+
+describe('getDotenv dynamic null/undefined semantics', () => {
+  it('dynamic function returning null deletes a previously-set key', async () => {
+    const vars = await getDotenv({
+      dotenvToken: '.testenv',
+      paths: ['./test/full'],
+      env: 'test',
+      dynamic: {
+        // APP_SETTING is loaded from dotenv files; returning null should delete it
+        APP_SETTING: () => null,
+      },
+    });
+    expect('APP_SETTING' in vars).toBe(false);
+  });
+
+  it('dynamic function returning undefined leaves existing value unchanged', async () => {
+    const vars = await getDotenv({
+      dotenvToken: '.testenv',
+      paths: ['./test/full'],
+      env: 'test',
+      dynamic: {
+        APP_SETTING: () => undefined,
+      },
+    });
+    // APP_SETTING should still have its dotenv-loaded value
+    expect(vars.APP_SETTING).toBe('deep_app_setting');
+  });
+
+  it('dynamic literal null deletes a key', async () => {
+    const vars = await getDotenv({
+      dotenvToken: '.testenv',
+      paths: ['./test/full'],
+      env: 'test',
+      dynamic: {
+        APP_SETTING: null,
+      },
+    });
+    expect('APP_SETTING' in vars).toBe(false);
+  });
+
+  it('dynamic literal undefined is a no-op', async () => {
+    const vars = await getDotenv({
+      dotenvToken: '.testenv',
+      paths: ['./test/full'],
+      env: 'test',
+      dynamic: {
+        APP_SETTING: undefined,
+      },
+    });
+    expect(vars.APP_SETTING).toBe('deep_app_setting');
+  });
+
+  it('dynamic function returning string sets the key (unchanged behavior)', async () => {
+    const vars = await getDotenv({
+      dotenvToken: '.testenv',
+      paths: ['./test/full'],
+      env: 'test',
+      dynamic: {
+        NEW_KEY: () => 'hello',
+      },
+    });
+    expect(vars.NEW_KEY).toBe('hello');
+  });
+});

--- a/src/core/getDotenv.dynamic.nulldelete.test.ts
+++ b/src/core/getDotenv.dynamic.nulldelete.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { getDotenv } from './getDotenv';
 
@@ -63,5 +63,30 @@ describe('getDotenv dynamic null/undefined semantics', () => {
       },
     });
     expect(vars.NEW_KEY).toBe('hello');
+  });
+
+  describe('loadProcess null-delete', () => {
+    const SENTINEL_KEY = '__GETDOTENV_NULL_DELETE_TEST__';
+
+    afterEach(() => {
+      Reflect.deleteProperty(process.env, SENTINEL_KEY);
+    });
+
+    it('dynamic null removes an existing key from process.env when loadProcess is true', async () => {
+      // Pre-seed process.env so the key exists before getDotenv runs.
+      process.env[SENTINEL_KEY] = 'should-be-removed';
+
+      await getDotenv({
+        dotenvToken: '.testenv',
+        paths: ['./test/full'],
+        env: 'test',
+        loadProcess: true,
+        dynamic: {
+          [SENTINEL_KEY]: () => null,
+        },
+      });
+
+      expect(SENTINEL_KEY in process.env).toBe(false);
+    });
   });
 });

--- a/src/core/getDotenv.ts
+++ b/src/core/getDotenv.ts
@@ -146,11 +146,17 @@ export async function getDotenv(
   );
 
   // Process dynamic variables. Programmatic option takes precedence over path.
+  const deletedKeys = new Set<string>();
   if (!excludeDynamic) {
     // A2 precedence: programmatic dynamic < dynamicPath (dynamicPath wins when present)
     if (options.dynamic && Object.keys(options.dynamic).length > 0) {
       try {
-        applyDynamicMap(dotenv, options.dynamic, env ?? defaultEnv);
+        for (const k of applyDynamicMap(
+          dotenv,
+          options.dynamic,
+          env ?? defaultEnv,
+        ))
+          deletedKeys.add(k);
       } catch {
         throw new Error(`Unable to evaluate dynamic variables.`);
       }
@@ -158,12 +164,13 @@ export async function getDotenv(
     // dynamicPath is evaluated even when programmatic `dynamic` is present.
     if (dynamicPath) {
       const absDynamicPath = path.resolve(dynamicPath);
-      await loadAndApplyDynamic(
+      for (const k of await loadAndApplyDynamic(
         dotenv,
         absDynamicPath,
         env ?? defaultEnv,
         'getdotenv-dynamic',
-      );
+      ))
+        deletedKeys.add(k);
     }
   }
   // Write output file.
@@ -231,6 +238,9 @@ export async function getDotenv(
 
   // Load process.env.
   if (loadProcess) {
+    for (const key of deletedKeys) {
+      Reflect.deleteProperty(process.env, key);
+    }
     for (const [key, value] of Object.entries(resultDotenv)) {
       if (value === undefined) Reflect.deleteProperty(process.env, key);
       else process.env[key] = value;

--- a/src/core/getDotenv.ts
+++ b/src/core/getDotenv.ts
@@ -230,7 +230,12 @@ export async function getDotenv(
   }
 
   // Load process.env.
-  if (loadProcess) Object.assign(process.env, resultDotenv);
+  if (loadProcess) {
+    for (const [key, value] of Object.entries(resultDotenv)) {
+      if (value === undefined) Reflect.deleteProperty(process.env, key);
+      else process.env[key] = value;
+    }
+  }
 
   return resultDotenv;
 }

--- a/src/env/dynamic.ts
+++ b/src/env/dynamic.ts
@@ -24,21 +24,25 @@ import { type DotenvDynamicSource, pushDotenvProvenance } from './provenance';
  * @param target - Mutable target environment to assign into.
  * @param map - Dynamic map to apply (functions and/or literal values).
  * @param env - Selected environment name (if any) passed through to dynamic functions.
- * @returns Nothing.
+ * @returns Set of keys that were deleted (value was null).
  */
 export function applyDynamicMap(
   target: ProcessEnv,
   map?: GetDotenvDynamic,
   env?: string,
-): void {
-  if (!map) return;
+): Set<string> {
+  const deleted = new Set<string>();
+  if (!map) return deleted;
   for (const key of Object.keys(map)) {
     const val =
       typeof map[key] === 'function' ? map[key](target, env) : map[key];
-    if (val === null) Reflect.deleteProperty(target, key);
-    else if (val !== undefined) target[key] = val;
+    if (val === null) {
+      Reflect.deleteProperty(target, key);
+      deleted.add(key);
+    } else if (val !== undefined) target[key] = val;
     // undefined → no-op
   }
+  return deleted;
 }
 
 /**
@@ -85,6 +89,8 @@ export async function loadDynamicModuleDefault(
  * @param prov - Provenance map to append into.
  * @param meta - Dynamic provenance metadata (source tier and optional dynamicPath).
  *
+ * @returns Set of keys that were deleted (value was null).
+ *
  * @public
  */
 export function applyDynamicMapWithProvenance(
@@ -93,13 +99,15 @@ export function applyDynamicMapWithProvenance(
   env: string | undefined,
   prov: DotenvProvenance,
   meta: { dynamicSource: DotenvDynamicSource; dynamicPath?: string },
-): void {
-  if (!map) return;
+): Set<string> {
+  const deleted = new Set<string>();
+  if (!map) return deleted;
   for (const key of Object.keys(map)) {
     const val =
       typeof map[key] === 'function' ? map[key](target, env) : map[key];
     if (val === null) {
       Reflect.deleteProperty(target, key);
+      deleted.add(key);
       pushDotenvProvenance(prov, key, {
         kind: 'dynamic',
         op: 'unset',
@@ -125,6 +133,7 @@ export function applyDynamicMapWithProvenance(
     }
     // undefined → no-op, no provenance entry
   }
+  return deleted;
 }
 
 /**
@@ -140,15 +149,15 @@ export function applyDynamicMapWithProvenance(
  * @param absPath - Absolute path to the dynamic module file.
  * @param env - Selected environment name (if any).
  * @param cacheDirName - Cache subdirectory under `.tsbuild/` for compiled artifacts.
- * @returns A `Promise\<void\>` which resolves after the module (if present) has been applied.
+ * @returns A `Promise\<Set\<string\>\>` resolving to the set of deleted keys.
  */
 export async function loadAndApplyDynamic(
   target: ProcessEnv,
   absPath: string,
   env: string | undefined,
   cacheDirName: string,
-): Promise<void> {
+): Promise<Set<string>> {
   const dyn = await loadDynamicModuleDefault(absPath, cacheDirName);
-  if (!dyn) return;
-  applyDynamicMap(target, dyn, env);
+  if (!dyn) return new Set<string>();
+  return applyDynamicMap(target, dyn, env);
 }

--- a/src/env/dynamic.ts
+++ b/src/env/dynamic.ts
@@ -16,8 +16,10 @@ import { type DotenvDynamicSource, pushDotenvProvenance } from './provenance';
 
 /**
  * Apply a dynamic map to the target progressively.
- * - Functions receive (target, env) and may return string | undefined.
- * - Literals are assigned directly (including undefined).
+ * - Functions receive (target, env) and may return string | null | undefined.
+ * - string → set the key to that value.
+ * - undefined → no-op, leave existing value unchanged.
+ * - null → delete the key from the target.
  *
  * @param target - Mutable target environment to assign into.
  * @param map - Dynamic map to apply (functions and/or literal values).
@@ -33,7 +35,9 @@ export function applyDynamicMap(
   for (const key of Object.keys(map)) {
     const val =
       typeof map[key] === 'function' ? map[key](target, env) : map[key];
-    Object.assign(target, { [key]: val });
+    if (val === null) Reflect.deleteProperty(target, key);
+    else if (val !== undefined) target[key] = val;
+    // undefined → no-op
   }
 }
 
@@ -94,17 +98,32 @@ export function applyDynamicMapWithProvenance(
   for (const key of Object.keys(map)) {
     const val =
       typeof map[key] === 'function' ? map[key](target, env) : map[key];
-    Object.assign(target, { [key]: val });
-    pushDotenvProvenance(prov, key, {
-      kind: 'dynamic',
-      op: typeof val === 'string' ? 'set' : 'unset',
-      dynamicSource: meta.dynamicSource,
-      ...(meta.dynamicSource === 'dynamicPath' &&
-      typeof meta.dynamicPath === 'string' &&
-      meta.dynamicPath.length > 0
-        ? { dynamicPath: meta.dynamicPath }
-        : {}),
-    });
+    if (val === null) {
+      Reflect.deleteProperty(target, key);
+      pushDotenvProvenance(prov, key, {
+        kind: 'dynamic',
+        op: 'unset',
+        dynamicSource: meta.dynamicSource,
+        ...(meta.dynamicSource === 'dynamicPath' &&
+        typeof meta.dynamicPath === 'string' &&
+        meta.dynamicPath.length > 0
+          ? { dynamicPath: meta.dynamicPath }
+          : {}),
+      });
+    } else if (val !== undefined) {
+      target[key] = val;
+      pushDotenvProvenance(prov, key, {
+        kind: 'dynamic',
+        op: 'set',
+        dynamicSource: meta.dynamicSource,
+        ...(meta.dynamicSource === 'dynamicPath' &&
+        typeof meta.dynamicPath === 'string' &&
+        meta.dynamicPath.length > 0
+          ? { dynamicPath: meta.dynamicPath }
+          : {}),
+      });
+    }
+    // undefined → no-op, no provenance entry
   }
 }
 


### PR DESCRIPTION
Dynamic null/undefined semantics for dynamic env vars. string sets, undefined is no-op, null deletes. Types widened config-side only. ProcessEnv unchanged. loadProcess fix. 5 new tests, all 230 pass.