### PR TITLE
fix(cli): wire cmdPlugin asDefault through ns() options bag

### DIFF
--- a/.prbody
+++ b/.prbody
@@ -1,14 +1,10 @@
-Fix lint, build, and code quality issues from the PR #33 merge.
+Wire CmdPluginOptions.asDefault through to Commander's command() isDefault option via a new NsOptions type on the plugin contract.
 
-**Quality checks passed:**
-- eslint: 0 errors, 0 warnings
-- tsc --noEmit: clean
-- rollup build: clean (no warnings)
-- vitest: 240 passed, 1 skipped
-- knip: only pre-existing noise (esbuild/fs-extra)
+- Add NsOptions interface (isDefault, hidden) to contracts.ts
+- Extend ns() in GetDotenvCli to accept NsOptions, forward to command()
+- Add optional nsOptions to GetDotenvCliPlugin contract
+- Pass plugin.nsOptions through registerPlugin to ns()
+- cmdPlugin factory maps options.asDefault into nsOptions.isDefault
+- Add regression test for default subcommand routing
 
-**Fixes:**
-- Prettier formatting in `attachRootOptions.ts` (debug flag block)
-- `@typescript-eslint/consistent-type-imports` violation in `defaultAction.ts` — replaced `typeof import()` type annotations with local variable typing and direct assignment from the dynamic import
-- Rollup build warning for AWS SDK type mismatch (same root cause)
-- Added `.commitmsg` to `.gitignore` to prevent ephemeral files from being tracked
+Fixes #35

--- a/.prbody
+++ b/.prbody
@@ -1,0 +1,14 @@
+Fix lint, build, and code quality issues from the PR #33 merge.
+
+**Quality checks passed:**
+- eslint: 0 errors, 0 warnings
+- tsc --noEmit: clean
+- rollup build: clean (no warnings)
+- vitest: 240 passed, 1 skipped
+- knip: only pre-existing noise (esbuild/fs-extra)
+
+**Fixes:**
+- Prettier formatting in `attachRootOptions.ts` (debug flag block)
+- `@typescript-eslint/consistent-type-imports` violation in `defaultAction.ts` — replaced `typeof import()` type annotations with local variable typing and direct assignment from the dynamic import
+- Rollup build warning for AWS SDK type mismatch (same root cause)
+- Added `.commitmsg` to `.gitignore` to prevent ephemeral files from being tracked

--- a/src/cliHost/GetDotenvCli.ts
+++ b/src/cliHost/GetDotenvCli.ts
@@ -24,6 +24,7 @@ import { buildHelpInformation } from './buildHelpInformation';
 import type {
   GetDotenvCliPlugin,
   GetDotenvCliPublic,
+  NsOptions,
   PluginChildEntry,
   PluginNamespaceOverride,
   ResolveAndLoadOptions,
@@ -250,6 +251,7 @@ export class GetDotenvCli<
    */
   ns<Usage extends string>(
     name: Usage,
+    opts?: NsOptions,
   ): GetDotenvCliPublic<
     TOptions,
     [...TArgs, ...InferCommandArguments<Usage>],
@@ -261,7 +263,10 @@ export class GetDotenvCli<
     if (exists) {
       throw new Error(`Duplicate command name: ${name}`);
     }
-    return this.command(name) as unknown as GetDotenvCliPublic<
+    return this.command(name, {
+      ...(opts?.isDefault !== undefined ? { isDefault: opts.isDefault } : {}),
+      ...(opts?.hidden !== undefined ? { hidden: opts.hidden } : {}),
+    }) as unknown as GetDotenvCliPublic<
       TOptions,
       [...TArgs, ...InferCommandArguments<Usage>],
       {},

--- a/src/cliHost/contracts.ts
+++ b/src/cliHost/contracts.ts
@@ -58,6 +58,7 @@ export interface GetDotenvCliPublic<
    */
   ns<Usage extends string>(
     name: Usage,
+    opts?: NsOptions,
   ): GetDotenvCliPublic<
     TOptions,
     [...TArgs, ...InferCommandArguments<Usage>],
@@ -121,6 +122,25 @@ export interface GetDotenvCliPublic<
 }
 
 /**
+ * Options for the `ns()` subcommand factory, forwarded to Commander's
+ * `command(name, opts)` second argument.
+ *
+ * @public
+ */
+export interface NsOptions {
+  /**
+   * When true, this subcommand becomes the default: Commander routes
+   * unrecognized positional tokens to it when no explicit subcommand matches.
+   */
+  isDefault?: boolean;
+
+  /**
+   * When true, the subcommand is hidden from help output.
+   */
+  hidden?: boolean;
+}
+
+/**
  * Optional overrides for plugin composition.
  *
  * @public
@@ -161,6 +181,12 @@ export interface GetDotenvCliPlugin<
 > {
   /** Namespace (required): the command name where this plugin is mounted. */
   ns: string;
+
+  /**
+   * Options forwarded to the host's `ns()` call when creating the mount
+   * for this plugin (e.g. `{ isDefault: true }`).
+   */
+  nsOptions?: NsOptions;
 
   /**
    * Setup phase: register commands and wiring on the provided mount.

--- a/src/cliHost/index.ts
+++ b/src/cliHost/index.ts
@@ -10,6 +10,7 @@ export type {
   GetDotenvCliPlugin,
   GetDotenvCliPublic,
   InferPluginConfig,
+  NsOptions,
   PluginChildEntry,
   PluginNamespaceOverride,
   PluginWithInstanceHelpers,

--- a/src/cliHost/registerPlugin.ts
+++ b/src/cliHost/registerPlugin.ts
@@ -36,7 +36,7 @@ function runInstall<TOptions extends GetDotenvOptions>(
   plugin: GetDotenvCliPlugin<TOptions, unknown[], OptionValues, OptionValues>,
 ): void | Promise<void> {
   // Create mount and run setup
-  const mount = parentCli.ns(plugin.ns);
+  const mount = parentCli.ns(plugin.ns, plugin.nsOptions);
   const setupRet = plugin.setup(mount);
   const pending: Promise<void>[] = [];
   if (isPromise(setupRet)) pending.push(setupRet.then(() => undefined));

--- a/src/plugins/cmd/alias.test.ts
+++ b/src/plugins/cmd/alias.test.ts
@@ -12,6 +12,45 @@ import { createCli } from '@/src/cli';
 
 import { cmdPlugin } from './index';
 
+describe('plugins/cmd default subcommand (asDefault)', () => {
+  beforeEach(() => {
+    execMock.mockClear();
+  });
+
+  it('routes positional args to cmd when asDefault is true', async () => {
+    const run = createCli({
+      alias: 'test',
+      compose: (p) =>
+        p.use(
+          cmdPlugin({ asDefault: true, optionAlias: '--cmd <command...>' }),
+        ),
+    });
+    await run(['node', 'test', 'echo', 'hello']);
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+    const [command] = execMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(command).toBe('echo hello');
+  });
+
+  it('does not route positional args when asDefault is false', async () => {
+    const run = createCli({
+      alias: 'test',
+      compose: (p) =>
+        p.use(
+          cmdPlugin({ asDefault: false, optionAlias: '--cmd <command...>' }),
+        ),
+    });
+
+    // Without asDefault, positional args hit the root no-op action;
+    // the cmd subcommand never fires.
+    await run(['node', 'test', 'echo', 'hello']);
+    expect(execMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('plugins/cmd option alias', () => {
   beforeEach(() => {
     execMock.mockClear();

--- a/src/plugins/cmd/index.ts
+++ b/src/plugins/cmd/index.ts
@@ -23,6 +23,7 @@ export type { RunCmdWithContextOptions } from './types';
 export const cmdPlugin = (options: CmdPluginOptions = {}) => {
   const plugin = definePlugin({
     ns: 'cmd',
+    ...(options.asDefault ? { nsOptions: { isDefault: true } } : {}),
     configSchema: cmdPluginConfigSchema,
     setup(cli) {
       const aliasSpec =


### PR DESCRIPTION
## Summary

Threads \CmdPluginOptions.asDefault\ through to Commander's \command()\ \isDefault\ option via a new \NsOptions\ type on the plugin contract.

## Problem

\getdotenv nr changelog\ throws \error: too many arguments. Expected 0 arguments but got 2\ while \getdotenv -c nr changelog\ works fine. \sDefault\ was declared on \CmdPluginOptions\ and passed at every call site but never consumed.

## Changes

- Add \NsOptions\ interface to \contracts.ts\ (\isDefault\, \hidden\)
- Extend \
s()\ in \GetDotenvCli\ to accept \NsOptions\, forward to \command()\
- Add optional \
sOptions\ to \GetDotenvCliPlugin\ contract
- Pass \plugin.nsOptions\ through \egisterPlugin\ to \
s()\
- \cmdPlugin\ factory maps existing \options.asDefault\ into \
sOptions.isDefault\
- Export \NsOptions\ from \cliHost/index.ts\

No changes to \CmdPluginOptions\ contract.

Fixes #35